### PR TITLE
Add workout type selection

### DIFF
--- a/src/components/AddWorkout.tsx
+++ b/src/components/AddWorkout.tsx
@@ -8,11 +8,12 @@ import {workoutToFile} from "@/utils/workoutToFile";
 import {addWorkout} from "@/addWorkout/addWorkout";
 
 export const AddWorkout = ({settings, context}: { settings?: WorkoutTrackerSettings, context: addWorkout }) => {
-	const [isExerciseAdding, setExerciseAdding] = useState(false);
-	const [date, setDate] = useState(new Date().toISOString().split('T')[0])
-	const [exercises, setExercises] = useState<{
-		[key: string]: string
-	}[]>([]);
+        const [isExerciseAdding, setExerciseAdding] = useState(false);
+        const [date, setDate] = useState(new Date().toISOString().split('T')[0])
+        const [workoutType, setWorkoutType] = useState(settings?.workoutTypes[0] || '')
+        const [exercises, setExercises] = useState<{
+                [key: string]: string
+        }[]>([]);
 	const [formValues, setFormValues] = useState<{ [key: string]: string }>({});
 	const app = useApp();
 
@@ -27,23 +28,33 @@ export const AddWorkout = ({settings, context}: { settings?: WorkoutTrackerSetti
 		}));
 	};
 
-	async function saveWorkout() {
-		if (!app || !settings?.workoutsFolder) return
-		await workoutToFile(app, settings ,exercises, settings.workoutsFolder, date);
-		context.close()
-	}
+        async function saveWorkout() {
+                if (!app || !settings?.workoutsFolder) return
+                await workoutToFile(app, settings ,exercises, settings.workoutsFolder, date, workoutType);
+                context.close()
+        }
 
 	return (
 		<div className="flex-col gap-1">
 			<h2>Adding workout</h2>
-			<input
-				type="date"
-				value={date}
-				onChange={(e) => {
-					setDate(e.target.value)
-				}}
-			/>
-			<button onClick={() => setExerciseAdding(true)}>Add exercise</button>
+                        <input
+                                type="date"
+                                value={date}
+                                onChange={(e) => {
+                                        setDate(e.target.value)
+                                }}
+                        />
+                        {settings?.workoutTypes && (
+                                <select
+                                        value={workoutType}
+                                        onChange={(e) => setWorkoutType(e.target.value)}
+                                >
+                                        {settings.workoutTypes.map((type) => (
+                                                <option key={type} value={type}>{type}</option>
+                                        ))}
+                                </select>
+                        )}
+                        <button onClick={() => setExerciseAdding(true)}>Add exercise</button>
 
 			{isExerciseAdding && (
 				<div className={'add-exercise'}>

--- a/src/components/BaseSettingsTab.tsx
+++ b/src/components/BaseSettingsTab.tsx
@@ -9,16 +9,21 @@ export const DEFAULT_SETTINGS: WorkoutTrackerSettings = {
 		{name: 'Weight', type: 'string'},
 		{name: 'Reps', type: 'number'}
 	],
-	muscleGroups: [
-		'Chest',
-		'Back',
-		'Legs',
-	],
-	exercises: [
-		{
-			name: 'Bench press',
-			muscleGroup: 'Chest'
-		}
+        muscleGroups: [
+                'Chest',
+                'Back',
+                'Legs',
+        ],
+        workoutTypes: [
+                'Push',
+                'Pull',
+                'Legs'
+        ],
+        exercises: [
+                {
+                        name: 'Bench press',
+                        muscleGroup: 'Chest'
+                }
 	]
 };
 
@@ -168,17 +173,81 @@ export default class BaseSettingsTab extends PluginSettingTab {
 
 		})
 
-		new Setting(this.containerEl).addButton((cb) => {
-			cb.setButtonText("Add new muscle group")
-				.setCta()
-				.onClick(async () => {
-					this.plugin.settings.muscleGroups.push("")
-					await this.plugin.saveSettings()
-					this.display()
-				});
-		});
+                new Setting(this.containerEl).addButton((cb) => {
+                        cb.setButtonText("Add new muscle group")
+                                .setCta()
+                                .onClick(async () => {
+                                        this.plugin.settings.muscleGroups.push("")
+                                        await this.plugin.saveSettings()
+                                        this.display()
+                                });
+                });
 
-		new Setting(containerEl).setName('Exercises').setHeading()
+                new Setting(containerEl).setName('Workout types').setHeading()
+
+                this.plugin.settings.workoutTypes.forEach((_, index) => {
+                        new Setting(containerEl)
+                                .addText(text => {
+                                        text.setValue(this.plugin.settings.workoutTypes[index]);
+                                        text.onChange(async (value) => {
+                                                this.plugin.settings.workoutTypes[index] = value
+                                                await this.plugin.saveSettings()
+                                        })
+                                })
+                                .addExtraButton((cb) => {
+                                        cb.setIcon("up-chevron-glyph")
+                                                .setTooltip("Move up")
+                                                .onClick(async () => {
+                                                        arraymove(
+                                                                this.plugin.settings.workoutTypes,
+                                                                index,
+                                                                index - 1
+                                                        );
+                                                        this.plugin.settings.workoutTypes;
+                                                        await this.plugin.saveSettings()
+                                                        this.display();
+                                                });
+                                })
+                                .addExtraButton((cb) => {
+                                        cb.setIcon("down-chevron-glyph")
+                                                .setTooltip("Move down")
+                                                .onClick(async () => {
+                                                        arraymove(
+                                                                this.plugin.settings.workoutTypes,
+                                                                index,
+                                                                index + 1
+                                                        );
+                                                        this.plugin.settings.workoutTypes;
+                                                        await this.plugin.saveSettings()
+                                                        this.display();
+                                                });
+                                })
+                                .addExtraButton((cb) => {
+                                        cb.setIcon("cross")
+                                                .setTooltip("Delete")
+                                                .onClick(async () => {
+                                                        this.plugin.settings.workoutTypes.splice(
+                                                                index,
+                                                                1
+                                                        );
+                                                        await this.plugin.saveSettings()
+                                                        this.display();
+                                                });
+                                });
+
+                })
+
+                new Setting(this.containerEl).addButton((cb) => {
+                        cb.setButtonText("Add new workout type")
+                                .setCta()
+                                .onClick(async () => {
+                                        this.plugin.settings.workoutTypes.push("")
+                                        await this.plugin.saveSettings()
+                                        this.display()
+                                });
+                });
+
+                new Setting(containerEl).setName('Exercises').setHeading()
 
 		this.plugin.settings.exercises.forEach((_, index) => {
 			new Setting(containerEl)

--- a/src/types/Settings.ts
+++ b/src/types/Settings.ts
@@ -1,11 +1,12 @@
 export interface WorkoutTrackerSettings {
-	workoutsFolder: string,
-	additionalExerciseParams: AdditionalExerciseParam[]
-	muscleGroups: string[]
-	exercises: [{
-		name: string
-		muscleGroup: string
-	}]
+        workoutsFolder: string,
+        additionalExerciseParams: AdditionalExerciseParam[]
+        muscleGroups: string[]
+        workoutTypes: string[]
+        exercises: [{
+                name: string
+                muscleGroup: string
+        }]
 }
 
 export interface AdditionalExerciseParam {

--- a/src/utils/getSortedExercises.ts
+++ b/src/utils/getSortedExercises.ts
@@ -18,15 +18,17 @@ function formatDateToYMD(input: string | Date): string {
 export function getSortedExercises(
 	app: App,
 	settings: WorkoutTrackerSettings,
-	date: string | Date | null = null,
-	removeMuscleKeys = false
+        date: string | Date | null = null,
+        removeMuscleKeys = false,
+        workoutType: string | null = null
 ) {
-	const folderPath = date
-		? normalizePath(`${settings.workoutsFolder}/${formatDateToYMD(date)}`)
-		: normalizePath(settings.workoutsFolder);
-	const allExercise = app.vault
-		.getFiles()
-		.filter((f) => f.path.includes(folderPath));
+        const basePath = date
+                ? normalizePath(`${settings.workoutsFolder}/${formatDateToYMD(date)}`)
+                : normalizePath(settings.workoutsFolder);
+        const folderPath = workoutType ? `${basePath}-${workoutType}` : basePath;
+        const allExercise = app.vault
+                .getFiles()
+                .filter((f) => f.path.startsWith(folderPath));
 
 	let sortedExercises: sortedExerciseType<typeof removeMuscleKeys> = {};
 

--- a/src/utils/getWorkoutsDates.ts
+++ b/src/utils/getWorkoutsDates.ts
@@ -5,11 +5,11 @@ export function getWorkoutsDate(app: App, settings: WorkoutTrackerSettings) {
 	const allWorkouts = app.vault.getFiles().filter(file => file.path.includes(normalizePath(settings.workoutsFolder)));
 	const workoutDays = new Set()
 
-	allWorkouts.forEach(workout => {
-		if (workout.parent?.name) {
-			workoutDays.add(workout.parent.name)
-		}
-	});
+        allWorkouts.forEach(workout => {
+                if (workout.parent?.name) {
+                        workoutDays.add(workout.parent.name.substring(0, 10))
+                }
+        });
 
 	return workoutDays as Set<string>;
 }

--- a/src/utils/workoutToFile.ts
+++ b/src/utils/workoutToFile.ts
@@ -3,16 +3,16 @@ import {getSortedExercises} from "@/utils/getSortedExercises";
 import {WorkoutTrackerSettings} from "@/types/Settings";
 
 export async function workoutToFile(app: App, settings: WorkoutTrackerSettings, exercises: {
-	[key: string]: string
-}[], workoutDir: string, date: string | Date) {
-	const dirPath = `${workoutDir}/${date}`;
+        [key: string]: string
+}[], workoutDir: string, date: string | Date, workoutType: string) {
+        const dirPath = `${workoutDir}/${date}-${workoutType}`;
 	const dir = app.vault.getAbstractFileByPath(dirPath);
 
 	if (!dir) {
 		await app.vault.createFolder(dirPath);
 	}
 
-	const sortedExercises = getSortedExercises(app, settings, date, true);
+        const sortedExercises = getSortedExercises(app, settings, date, true, workoutType);
 
 	for (const index in exercises) {
 		const exercise = exercises[index];
@@ -21,7 +21,7 @@ export async function workoutToFile(app: App, settings: WorkoutTrackerSettings, 
 
 		let totalIndex =  existingExercisesInDay && Array.isArray(existingExercisesInDay) ? numericIndex + existingExercisesInDay.length + 1 : numericIndex + 1
 
-		const fileName = normalizePath(`${workoutDir}/${date}/${exercise.selectedExercise}-${totalIndex}.md`);
+                const fileName = normalizePath(`${workoutDir}/${date}-${workoutType}/${exercise.selectedExercise}-${totalIndex}.md`);
 
 		const file = app.vault.getAbstractFileByPath(fileName);
 


### PR DESCRIPTION
## Summary
- allow storing workouts in subfolders by type
- expose workout types in default settings
- add settings section to manage workout types
- select workout type when adding a workout

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685f0d857ac88325bbcd92f123fdfd0a